### PR TITLE
Extend functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ libraries/
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 publish/
+source/packages/

--- a/source/App_Config/Include/SharedSource/SharedSource.RedirectModule.config
+++ b/source/App_Config/Include/SharedSource/SharedSource.RedirectModule.config
@@ -55,6 +55,7 @@
       <setting name="SharedSource.RedirectModule.RedirectionType.ExactMatch" value="true"/>
       <setting name="SharedSource.RedirectModule.RedirectionType.Pattern" value="true"/>
       <setting name="SharedSource.RedirectModule.RedirectionType.Rules" value="true"/>
+      <setting name="SharedSource.RedirectModule.RedirectAnything" value="true"/>
 
       <!--  RedirectRootNode
             The module stores the rules as items in the Sitecore tree.  You can move the root node if needed.

--- a/source/Helpers/Constants.cs
+++ b/source/Helpers/Constants.cs
@@ -8,6 +8,7 @@ namespace SharedSource.RedirectModule.Helpers
         {
             public static string VisitorIdentification = "/layouts/system/visitoridentification";
             public static string MediaLibrary = "/sitecore/media library/";
+            public static string Sitecore = "/sitecore";
         }
 
         public static class Settings

--- a/source/Helpers/Constants.cs
+++ b/source/Helpers/Constants.cs
@@ -19,6 +19,7 @@ namespace SharedSource.RedirectModule.Helpers
             public static string QueryPatternMatch = "SharedSource.RedirectModule.QueryType.PatternMatch";
             public static string RedirectRootNode = "SharedSource.RedirectModule.RedirectRootNode";
             public static string AutoGenerateRedirectsOnMove = "SharedSource.RedirectModule.AutoGenerateRedirectsOnMove";
+            public static string RedirectAnything = "SharedSource.RedirectModule.RedirectAnything";
 
         }
         public static class Templates

--- a/source/Processors/RedirectProcessor.cs
+++ b/source/Processors/RedirectProcessor.cs
@@ -113,7 +113,8 @@ namespace SharedSource.RedirectModule.Processors
                 var redirectToItem = db.GetItem(path);
                 if (redirectToItem == null)
                 {
-                    if (LinkManager.GetDefaultUrlBuilderOptions() != null && (bool)LinkManager.GetDefaultUrlBuilderOptions().EncodeNames)
+                    var options = LinkManager.GetDefaultUrlOptions();
+                    if (options != null && options.EncodeNames)
                     {
                         path = Sitecore.MainUtil.DecodeName(path);
                     }
@@ -164,6 +165,9 @@ namespace SharedSource.RedirectModule.Processors
 
         private static bool AllowRedirectsOnFoundItem(Database db)
         {
+            bool redirectanything = Sitecore.Configuration.Settings.GetBoolSetting(Constants.Settings.RedirectAnything,true);
+            if (redirectanything)
+                return true;
             if (db == null)
                 return false;
             var redirectRoot = Sitecore.Configuration.Settings.GetSetting(Constants.Settings.RedirectRootNode);

--- a/source/Processors/RedirectProcessor.cs
+++ b/source/Processors/RedirectProcessor.cs
@@ -28,7 +28,7 @@ namespace SharedSource.RedirectModule.Processors
             // This processor is added to the pipeline after the Sitecore Item Resolver.  We want to skip everything if the item resolved successfully.
             // Also, skip processing for the visitor identification items related to DMS.
             Assert.ArgumentNotNull(args, "args");
-            if ((Sitecore.Context.Item == null || AllowRedirectsOnFoundItem(Sitecore.Context.Database)) && args.LocalPath != Constants.Paths.VisitorIdentification && Sitecore.Context.Database != null)
+            if ((Sitecore.Context.Item == null || AllowRedirectsOnFoundItem(Sitecore.Context.Database)) && !args.LocalPath.StartsWith(Constants.Paths.Sitecore,StringComparison.InvariantCultureIgnoreCase) && args.LocalPath != Constants.Paths.VisitorIdentification && Sitecore.Context.Database != null)
             {
                 // Grab the actual requested path for use in both the item and pattern match sections.
                 var requestedUrl = HttpContext.Current.Request.Url.ToString();

--- a/source/RedirectModule.csproj
+++ b/source/RedirectModule.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Processors\RedirectProcessor.cs" />
     <Compile Include="Classes\ResponseStatus.cs" />
+    <Compile Include="Rules\Actions\ReplaceStringAdvanced.cs" />
     <Compile Include="Rules\Actions\ReplaceString.cs" />
     <Compile Include="Rules\Conditions\URLStringCondition.cs" />
   </ItemGroup>

--- a/source/Rules/Actions/ReplaceStringAdvanced.cs
+++ b/source/Rules/Actions/ReplaceStringAdvanced.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Web;
+
+namespace SharedSource.RedirectManager.Rules.Actions
+{
+    public class ReplaceStringAdvanced<T> : Sitecore.Rules.Actions.RuleAction<T> where T : Sitecore.Rules.RuleContext
+    {
+        public string Old { get; set; }
+        public string New { get; set; }
+
+        public override void Apply(T ruleContext)
+        {
+            if (ruleContext.Parameters["newUrl"] != null)
+            {
+                string str = (string)ruleContext.Parameters["newUrl"];
+                ruleContext.Parameters["newUrl"] = Regex.Replace(str, Old, New, RegexOptions.IgnoreCase);
+            }
+        }
+    }
+}


### PR DESCRIPTION
New action supporting regular expressions
Enable redirection of any url without checking if the item exists.
Use old and deprecated Linkbuilder default options for backwards compatibility